### PR TITLE
Add standard workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Something is not working as it should
+title: ''
+labels: ''
+assignees: ''
+---
+
+**Describe the bug**  
+A clear and concise description of what the bug is.
+
+**To Reproduce**  
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**  
+A clear and concise description of what you expected to happen.
+
+**Screenshots & Logfiles**  
+If applicable, add screenshots and logfiles to help explain your problem.
+
+**Versions:**  
+ - Adapter version: <adapter-version>
+ - JS-Controller version: <js-controller-version> <!-- determine this with `iobroker -v` on the console -->
+ - Node version: <node-version> <!-- determine this with `node -v` on the console -->
+ - Operating system: <os-name>
+
+**Additional context**  
+Add any other context about the problem here.

--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,17 @@
+# Configure here which dependency updates should be merged automatically.
+# The recommended configuration is the following:
+- match:
+    # Only merge patches for production dependencies
+    dependency_type: production
+    update_type: "semver:patch"
+- match:
+    # Except for security fixes, here we allow minor patches
+    dependency_type: production
+    update_type: "security:minor"
+- match:
+    # and development dependencies can have a minor update, too
+    dependency_type: development
+    update_type: "semver:minor"
+
+# The syntax is based on the legacy dependabot v1 automerged_updates syntax, see:
+# https://dependabot.com/docs/config-file/#automerged_updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "04:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    assignees:
+      - Author
+    versioning-strategy: increase
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "04:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    assignees:
+      - Author

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+# Automatically merge Dependabot PRs when version comparison is within the range
+# that is configured in .github/auto-merge.yml
+
+name: Auto-Merge Dependabot PRs
+
+on:
+  # WARNING: This needs to be run in the PR base, DO NOT build untrusted code in this action
+  # details under https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+  pull_request_target:
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Check if PR should be auto-merged
+        uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          # In order to use this, you need to go to https://github.com/settings/tokens and
+          # create a Personal Access Token with the permission "public_repo".
+          # Enter this token in your repository settings under "Secrets" and name it AUTO_MERGE_TOKEN
+          github-token: ${{ secrets.AUTO_MERGE_TOKEN }}
+          # By default, squash and merge, so Github chooses nice commit messages
+          command: squash and merge

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -1,0 +1,92 @@
+name: Test and Release
+
+# Run this job on all pushes and pull requests
+# as well as tags with a semantic version
+on:
+  push:
+    branches:
+      - "main"
+    tags:
+      # normal versions
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      # pre-releases
+      - "v[0-9]+.[0-9]+.[0-9]+-**"
+  pull_request: {}
+
+# Cancel previous PR/branch runs when a new commit is pushed
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Performs quick checks before the expensive test runs
+  check-and-lint:
+    if: contains(github.event.head_commit.message, '[skip ci]') == false
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: ioBroker/testing-action-check@v1
+        with:
+          node-version: '20.x'
+          # Uncomment the following line if your adapter cannot be installed using 'npm ci'
+          # install-command: 'npm install'
+          lint: true
+
+  # Runs adapter tests on all supported node versions and OSes
+  adapter-tests:
+    if: contains(github.event.head_commit.message, '[skip ci]') == false
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: ioBroker/testing-action-adapter@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+          os: ${{ matrix.os }}
+          # Uncomment the following line if your adapter cannot be installed using 'npm ci'
+          # install-command: 'npm install'
+
+# TODO: To enable automatic npm releases, create a token on npmjs.org 
+# Enter this token as a GitHub secret (with name NPM_TOKEN) in the repository options
+# Then uncomment the following block:
+
+#  # Deploys the final package to NPM
+#  deploy:
+#    needs: [check-and-lint, adapter-tests]
+#
+#    # Trigger this step only when a commit on any branch is tagged with a version number
+#    if: |
+#      contains(github.event.head_commit.message, '[skip ci]') == false &&
+#      github.event_name == 'push' &&
+#      startsWith(github.ref, 'refs/tags/v')
+#
+#    runs-on: ubuntu-latest
+#
+#    # Write permissions are required to create Github releases
+#    permissions:
+#      contents: write
+#
+#    steps:
+#      - uses: ioBroker/testing-action-deploy@v1
+#        with:
+#          node-version: '20.x'
+#          # Uncomment the following line if your adapter cannot be installed using 'npm ci'
+#          # install-command: 'npm install'
+#          npm-token: ${{ secrets.NPM_TOKEN }}
+#          github-token: ${{ secrets.GITHUB_TOKEN }}
+#
+#          # When using Sentry for error reporting, Sentry can be informed about new releases
+#          # To enable create a API-Token in Sentry (User settings, API keys)
+#          # Enter this token as a GitHub secret (with name SENTRY_AUTH_TOKEN) in the repository options
+#          # Then uncomment and customize the following block:
+#          sentry: true
+#          sentry-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+#          sentry-project: "iobroker-template"
+#          sentry-version-prefix: "iobroker.template"
+#          # If your sentry project is linked to a GitHub repository, you can enable the following option
+#          # sentry-github-integration: true


### PR DESCRIPTION
This PR adds standard workflows to 
- enable github based testing
- enable dependabot

Usage of dependabot is optional but recommended. So if you really do not want to use it, feel free to delete.

Note that eslint is failing die to missing configuration. I'll trigger a issue with instructions soon.

Fell free to contact me if you have any questions.